### PR TITLE
Decode crypto_json_txt to UTF8

### DIFF
--- a/res/bcdatafile.py
+++ b/res/bcdatafile.py
@@ -59,7 +59,7 @@ class DataFile:
 
         # JSON data (file content and encryption information)
         #crypto_json_txt  = d_file.read(self.header_core_length)
-        crypto_json_txt  = self.raw[48:48+self.header_core_length]
+        crypto_json_txt  = self.raw[48:48+self.header_core_length].decode('utf-8')
         self.crypto_json = json.loads(crypto_json_txt)
 
         # JSON Parsing


### PR DESCRIPTION
The JSON contains a name element containing the filename which is encoded as UTF8. Having non-ASCII characters in there will produce a TypeError: the JSON object must be str, not 'bytes'.